### PR TITLE
Add analytics script to head

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,14 @@
             color: var(--secondary-color);
         }
     </style>
+    
+    <!-- Analytics -->
+    <script
+      defer
+      data-website-id="687e582ea4a3f0b6ffad1ca7"
+      data-domain="pierrebaptiste.me"
+      src="https://datafa.st/js/script.js">
+    </script>
 </head>
 <body>
     <h1>pierre-baptiste borges</h1>


### PR DESCRIPTION
Add Datafast analytics script to `index.html` for website tracking.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2af3ad9-2281-4617-ba42-0e7793837fe1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2af3ad9-2281-4617-ba42-0e7793837fe1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

